### PR TITLE
Webpack migration  fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,31 +1,16 @@
-import slide1 from "./images/photo0.jpg";
-import slide2 from "./images/photo1.jpg";
-import slide3 from "./images/photo8.jpg";
-import slide4 from "./images/photo25.jpg";
-
 import "./styles/index.scss";
 import "./icons/font/_flaticon.scss";
 
-import downArrow from "./icons/png/next.png";
 import editIcon from "./icons/png/edit1.png";
 import addIcon from "./icons/png/016-add.png";
 import closeIcon from "./icons/png/001-cancel-3.png";
 
-const firstClone = document.querySelector(".first-clone img");
-firstClone.src = slide1;
-const lastClone = document.querySelector(".last-clone img");
-lastClone.src = slide4;
-const firstSlide = document.querySelector(".slide-1 img");
-firstSlide.src = slide1;
-const secondSlide = document.querySelector(".slide-2 img");
-secondSlide.src = slide2;
-const thirdSlide = document.querySelector(".slide-3 img");
-thirdSlide.src = slide3;
-const fourthSlide = document.querySelector(".slide-4 img");
-fourthSlide.src = slide4;
+import destinationsList from "./js/store.js";
+import moduleDestinations from "./js/modules/list.js";
+import moduleCarousel from "./js/modules/carousel.js";
 
-const scrollDown = document.querySelector(".heading__scroll-icon");
-scrollDown.src = downArrow;
+import addPhoto from "./js/modules/add_photo.js";
+import events from "./js/modules/pubsub.js";
 
 const addBtn = document.querySelector(".btn__add");
 const iconSpan = document.createElement("img");
@@ -37,11 +22,5 @@ const closeIconEl = document.createElement("img");
 closeBtn.appendChild(closeIconEl);
 closeIconEl.src = closeIcon;
 
-import destinationsList from "./js/store.js";
-import moduleDestinations from "./js/modules/list.js";
-import moduleCarousel from "./js/modules/carousel.js";
-
-import addPhoto from "./js/modules/add_photo.js";
-import events from "./js/modules/pubsub.js";
 moduleDestinations.init();
 addPhoto.init();

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,12 @@
 import "./styles/index.scss";
 import "./icons/font/_flaticon.scss";
 
-import editIcon from "./icons/png/edit1.png";
-import addIcon from "./icons/png/016-add.png";
-import closeIcon from "./icons/png/001-cancel-3.png";
-
-import destinationsList from "./js/store.js";
+import carousel from "./js/modules/carousel.js";
 import moduleDestinations from "./js/modules/list.js";
-import moduleCarousel from "./js/modules/carousel.js";
-
 import addPhoto from "./js/modules/add_photo.js";
-import events from "./js/modules/pubsub.js";
 
-const addBtn = document.querySelector(".btn__add");
-const iconSpan = document.createElement("img");
-addBtn.appendChild(iconSpan);
-iconSpan.src = addIcon;
+import "./js/modules/pubsub.js";
 
-const closeBtn = document.querySelector(".form__close-btn");
-const closeIconEl = document.createElement("img");
-closeBtn.appendChild(closeIconEl);
-closeIconEl.src = closeIcon;
-
+carousel.init();
 moduleDestinations.init();
 addPhoto.init();

--- a/src/js/modules/add_photo.js
+++ b/src/js/modules/add_photo.js
@@ -12,6 +12,17 @@ let formState = {
   photo: null,
 };
 
+function attachImgs() {
+  const addBtn = document.querySelector(".btn__add");
+  const iconSpan = document.createElement("img");
+  addBtn.appendChild(iconSpan);
+  iconSpan.src = require("../../icons/png/016-add.png");
+  const closeBtn = document.querySelector(".form__close-btn");
+  const closeIconEl = document.createElement("img");
+  closeBtn.appendChild(closeIconEl);
+  closeIconEl.src = require("../../icons/png/001-cancel-3.png");
+}
+
 function cacheDom() {
   form = document.getElementById("add-photo-form");
   radioBtns = document.querySelectorAll("input[type=radio]");
@@ -64,6 +75,7 @@ function initRadioBtn() {
 }
 
 function init() {
+  attachImgs();
   cacheDom();
   bindEvents();
   initRadioBtn();

--- a/src/js/modules/carousel.js
+++ b/src/js/modules/carousel.js
@@ -99,4 +99,5 @@ function init() {
   startSlide();
 }
 
-init();
+const module = { init };
+export default module;

--- a/src/js/modules/carousel.js
+++ b/src/js/modules/carousel.js
@@ -8,6 +8,21 @@ let slideWidth;
 let firstClone;
 let lastClone;
 
+function attachImgs() {
+  // The images attach must be done before the rest of JS manipulation
+  const firstSlide = document.querySelector(".slide-1 img");
+  firstSlide.src = require("../../images/photo0.jpg");
+  const secondSlide = document.querySelector(".slide-2 img");
+  secondSlide.src = require("../../images/photo1.jpg");
+  const thirdSlide = document.querySelector(".slide-3 img");
+  thirdSlide.src = require("../../images/photo8.jpg");
+  const fourthSlide = document.querySelector(".slide-4 img");
+  fourthSlide.src = require("../../images/photo25.jpg");
+
+  const scrollDown = document.querySelector(".heading__scroll-icon");
+  scrollDown.src = require("../../icons/png/next.png");
+}
+
 function cacheDom() {
   slideContainer = document.querySelector(".slides");
   nextBtn = document.querySelector(".next-btn");
@@ -77,9 +92,11 @@ function startSlide() {
 }
 
 function init() {
+  attachImgs();
   cacheDom();
   bindEvents();
   render();
   startSlide();
 }
+
 init();

--- a/src/styles/_main-page.scss
+++ b/src/styles/_main-page.scss
@@ -283,13 +283,14 @@ button {
   top: -10rem;
   right: 1rem;
   float: right;
+
   &::before {
     //edit icon
     content: "";
     height: 2rem;
     width: 2rem;
     display: inline-block;
-    // background-image: url("./icons/png/edit1.png");
+    background-image: url("../icons/png/edit1.png");
     background-size: cover;
   }
   &:hover {


### PR DESCRIPTION
Fixes problems raised in https://github.com/majac91/Photography_portfolio/pull/1.

- Carousel: The images path need to be attached to the DOM before the rest of JS work (eg clone the slides)
- Move the images imports closer to the respective modules (see `attachImgs` functions)
- Make the imports at index.js consistent, by adding the missing export `init`.
- Fix the img path of "Edit photo" button.

Regarding the `Flaticon` font family, I couldn't make it work. I suggest you opening a question on Stackoverflow with this question. Remember to provide the needed info: the webpack config, the imports and maybe a screenshot. The repo link for the correct commit/branch is also useful for people to try it out.